### PR TITLE
PROD Deploy: Add new Icon Tile, ScerIS

### DIFF
--- a/src/configs/prod/apps.yaml
+++ b/src/configs/prod/apps.yaml
@@ -112,6 +112,11 @@ categories:
         icon: https://assets.boston.gov/icons/accessboston/gov_qa.svg
         groups:
           - SG_AB_GOVQA
+      - title: ScerIS
+        url: https://sso.boston.gov/idp/startSSO.ping?PartnerSpId=urn%3Asso%3AScerIS
+        icon: https://assets.boston.gov/icons/accessboston/sceris.svg
+        groups:
+          - SG_AB_Sceris
 
   - title: Forms / Links
     apps:


### PR DESCRIPTION
Issue: https://github.com/CityOfBoston/digital/issues/758

TITLE: ScerIS
URL: https://sso.boston.gov/idp/startSSO.ping?PartnerSpId=urn%3Asso%3AScerIS
GROUP: SG_AB_Sceris
ICON: https://assets.boston.gov/icons/accessboston/sceris.svg
