### PR TITLE
Deploy Prod: DiG-4060 - 5yr Anniversary Banner

### DIFF
--- a/src/configs/prod/apps.yaml
+++ b/src/configs/prod/apps.yaml
@@ -1,3 +1,7 @@
+notice:
+  label: 'Notice'
+  pretext: ''
+  text: 'The Access Boston Portal turns 5 today - Happy Birthday!'
 categories:
   - title: Applications
     show_request_access_link: false


### PR DESCRIPTION
### 5 Year Anniversary for APB Banner

Due: April 1st
Text: `The Access Boston Portal turns 5 today - Happy Birthday!`