### PR TITLE
[PROD] DIG-4376: Portal Banner for May 17-20 upgrade

### DIFF
--- a/src/configs/prod/apps.yaml
+++ b/src/configs/prod/apps.yaml
@@ -1,3 +1,7 @@
+notice:
+  label: 'Notice'
+  pretext: ''
+  text: 'BAIS HCM, BAIS FN, Employee Self-Service (ESS), and the Beacon HR Portal will not be available from 11 a.m., Friday, May 17, through the morning of Monday, May 20, 2024.'
 categories:
   - title: Applications
     show_request_access_link: false


### PR DESCRIPTION
In preparation for the BAIS PUM upgrade the weekend of May 17-20, Dawn Necomb is asking that we add a banner to the Access Boston portal page from 5/3/2024 - 5/20/2024.

The team wants the text below added as a banner on the Access Boston landing page:

This is the updated message per Dawn 5/2:

NOTICE: `BAIS HCM, BAIS FN, Employee Self-Service (ESS), and the Beacon HR Portal will not be available from 11 a.m., Friday, May 17, through the morning of Monday, May 20, 2024.`