### PR TITLE
DIG-4114: Replace Travis deploy with Github Actions

### DIFF
--- a/.github/workflows/deploy_to_s3.yml
+++ b/.github/workflows/deploy_to_s3.yml
@@ -1,0 +1,117 @@
+# @file: deploy_to_s3.yml
+# This Action builds a deploy artifact (which in this case is a fully populated config, vendor and docroot folder for a
+# Dupal website) and copies the built folders+files to an s3 bucket.
+#
+# Attached resources:
+# - GitHub SECRETS:
+#     -> global: AWS_ACCESS_KEY -> AWS Authentication using a SERVICE ACCOUNT
+#     -> global: AWS_SECRET_ACCESS_KEY -> WeAWS Authentication using a SERVICE ACCOUNT
+#     -> global: SLACK_DOIT_WEBHOOK_URL -> Webhook URL for posting messages to slack
+# - GitHub VARIABLES:
+#     -> global: SLACK_MONITORING_CHANNEL -> Channel to post devops messages into
+#     -> local: S3_DRY_RUN -> Copies a single file into the s3 bucket DRY_RUN folder (for testing)
+#     -> local: DEPLOY_DEBUG -> Debug mode, generally prints more output for debugging
+#     -> local: RUN_JEST -> Launch Jest tests as part of action
+name: "Deploy Patterns to Amazon S3"
+on:
+  workflow_dispatch:
+  push:
+    branches:   # we can add branches to this list which will deploy code to Acquia GitLab as we push code to those branches.
+     - deploy-dev
+     - deploy-test
+     - deploy-prod
+      # - dummy
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOIT_WEBHOOK_URL }}    # for slack
+  NODE_VERSION: 14
+  TZ: "America/New_York"
+
+jobs:
+  Deploy:
+    # installed software: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # checkout the cob repository that has been pushed to.
+      - name: Set Variables
+        run: |
+          if [[ "${{ github.ref_name }}" == "deploy-dev" ]]; then
+            echo "BUCKET_NAME=cob-digital-apps-staging-static" >> "${GITHUB_ENV}"
+            echo "SOURCE_DIR='src/configs/dev'" >> "${GITHUB_ENV}"
+            echo "S3_DEST_DIR='access-boston-config/dev'" >> "${GITHUB_ENV}"
+          elif [[ "${{ github.ref_name }}" == "deploy-test" ]]; then
+            echo "BUCKET_NAME=cob-digital-apps-staging-static" >> "${GITHUB_ENV}"
+            echo "SOURCE_DIR='src/configs/test'" >> "${GITHUB_ENV}"
+            echo "S3_DEST_DIR='access-boston-config/test'" >> "${GITHUB_ENV}"
+          elif [[ "${{ github.ref_name }}" == "deploy-prod" ]]; then
+            echo "BUCKET_NAME=cob-digital-apps-prod-static" >> "${GITHUB_ENV}"
+            echo "SOURCE_DIR='src/configs/prod'" >> "${GITHUB_ENV}"
+            echo "S3_DEST_DIR='access-boston-config'" >> "${GITHUB_ENV}"
+          fi
+          if [[ ${{ vars.S3_DRY_RUN }} == 1 ]];then
+            echo "S3_DEST_DIR='DRY_RUN/'" >> "${GITHUB_ENV}"
+            echo "SOURCE_DIR='src/configs'" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Post to Slack
+        uses: act10ns/slack@v2.0.0
+        with:
+          status: Starting
+          channel: ${{ vars.SLACK_MONITORING_CHANNEL }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Downgrade node 14
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Build the public folder
+        id: Build-Patterns-And-CDN-Assets
+        run: |
+          npm install
+          npm run build
+
+      - name: Printout vars
+        if: ${{ vars.DEPLOY_DEBUG == 1 }}
+        run: |
+          du ./public
+
+      - name: Run Jest Tests
+        if: ${{ vars.RUN_JEST == 1 }}
+        run: |
+          npm run test
+
+      - name: Upload to Amazon
+        id: Deploy-To-Amazon
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks # --delete
+        env:
+          AWS_S3_BUCKET: ${{ env.BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-2'
+          SOURCE_DIR: ${{ env.SOURCE_DIR }}
+          DEST_DIR: ${{ env.S3_DEST_DIR }}
+
+      - name: Post to Slack - success
+        uses: act10ns/slack@v2.0.0
+        if: ${{ success()  }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: ${{ vars.SLACK_MONITORING_CHANNEL }}
+
+      - name: Post to Slack - failure
+        uses: act10ns/slack@v2.0.0
+        if: ${{ failure() }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: ${{ vars.SLACK_MONITORING_CHANNEL }}


### PR DESCRIPTION
#### Use Github Actions to push file updates to `dev/test/prod` config files for AB Dashboard (icons & links)

##### Dev
- `src/configs/dev` >>> `cob-digital-apps-staging-static/access-boston-config/dev`
##### Test
- `src/configs/test` >>> `cob-digital-apps-staging-static/access-boston-config/test`
##### Prod
- `src/configs/prod` >>> `cob-digital-apps-prod-static/access-boston-config`

These directories have `LAMDAs` watchers that then copy/replace the `apps.yaml` in the corresponding directory in:
- `cob-digital-apps-staging-config/access-boston/dev`
- `cob-digital-apps-staging-config/access-boston/test`
- `cob-digital-apps-prod-config/access-boston`


